### PR TITLE
download warningcards as png in flexible size

### DIFF
--- a/src/components/WarningCard.js
+++ b/src/components/WarningCard.js
@@ -8,9 +8,6 @@ const WarningCardDiv = styled.div`
   align-items: center;
   border: 5px solid #f25260;
   background: white;
-  height: 550px;
-  width: 350px;
-  margin: 10px 0px 10px 20px;
 `;
 const Image = styled.img`
   width: 250px;

--- a/src/pages/Card.js
+++ b/src/pages/Card.js
@@ -1,12 +1,11 @@
 import React from "react";
-import Header from "../components/Header";
-import Navigation from "../components/Navigation";
-import Select from "../components/Select";
 import WarningCard from "../components/WarningCard";
 import Button from "../components/Button";
 import NavButton from "../components/NavButton";
 import styled from "styled-components";
 import DownloadIcon from "../icons/downloadIcon";
+import jsPDF from "jspdf";
+import html2canvas from "html2canvas";
 
 const ButtonContainer = styled.div`
   display: flex;
@@ -24,25 +23,34 @@ const languages = [
   "thai",
   "swedish"
 ];
+const CardContainer = styled.div`
+  height: 80vh;
+  width: 100vw;
+  position: relative;
+`;
+
 export default function Home() {
   return (
     <>
-      <Header />
-      <Navigation />
-      <Select name="language">
-        {languages.map(language => (
-          <option name={language} key={language}>
-            {language}
-          </option>
-        ))}
-      </Select>
-      <WarningCard
-        src="/images/milkWarning.svg"
-        text="चेतावनी मृत्युको खतरा: मैले दुग्ध पदार्थ अथवा यो भएको खाना एलर्जीका कारणले खान मिल्दैन। यदि खानामा रैछ भने एलर्जीले मरणाशन्न हुनेछु।"
-        alt="no milk"
-      />
+      <CardContainer id="divToPrint">
+        <WarningCard
+          src="/images/milkWarning.svg"
+          text="चेतावनी मृत्युको खतरा: मैले दुग्ध पदार्थ अथवा यो भएको खाना एलर्जीका कारणले खान मिल्दैन। यदि खानामा रैछ भने एलर्जीले मरणाशन्न हुनेछु।"
+          alt="no milk"
+        />
+      </CardContainer>
       <ButtonContainer>
-        <Button>
+        <Button
+          id="download"
+          onEvent={() => {
+            html2canvas(document.querySelector("#divToPrint")).then(function(
+              canvas
+            ) {
+              console.log(canvas);
+              saveAs(canvas.toDataURL(), "file-name.png");
+            });
+          }}
+        >
           <DownloadIcon />
           Download
         </Button>
@@ -50,4 +58,24 @@ export default function Home() {
       </ButtonContainer>
     </>
   );
+}
+
+function saveAs(uri, filename) {
+  const link = document.createElement("a");
+
+  if (typeof link.download === "string") {
+    link.href = uri;
+    link.download = filename;
+
+    //Firefox requires the link to be in the body
+    document.body.appendChild(link);
+
+    //simulate click
+    link.click();
+
+    //remove the link when done
+    document.body.removeChild(link);
+  } else {
+    window.open(uri);
+  }
 }

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -12,7 +12,6 @@ import Button from "../components/Button";
 import NavButton from "../components/NavButton";
 import styled from "styled-components";
 import DownloadIcon from "../icons/downloadIcon";
-import jsPDF from "jspdf";
 import html2canvas from "html2canvas";
 
 async function getAllergies() {
@@ -29,8 +28,8 @@ const ButtonContainer = styled.div`
 `;
 
 const CardContainer = styled.div`
-  height: 100%;
-  width: 100%;
+  width: 90vw;
+  margin: auto;
 `;
 
 export default function Main() {
@@ -52,20 +51,6 @@ export default function Main() {
   }
   const allergy = allergyFilterSelection;
   const language = languageFilterSelection;
-
-  function printDocument() {
-    const input = document.getElementById("divToPrint");
-    html2canvas(input).then(canvas => {
-      const imgData = canvas.toDataURL("image/png");
-      const pdf = new jsPDF({
-        orientation: "portrait",
-        unit: "px",
-        format: [830, 530]
-      });
-      pdf.addImage(imgData, "JPEG", -20, -10);
-      pdf.save("warningcard.pdf");
-    });
-  }
 
   return (
     <>
@@ -105,8 +90,14 @@ export default function Main() {
           </CardContainer>
           <ButtonContainer>
             <Button
+              id="download"
               onEvent={() => {
-                printDocument();
+                html2canvas(document.querySelector("#divToPrint")).then(
+                  function(canvas) {
+                    console.log(canvas);
+                    saveAs(canvas.toDataURL(), "file-name.png");
+                  }
+                );
               }}
             >
               <DownloadIcon />
@@ -118,4 +109,23 @@ export default function Main() {
       </Switch>
     </>
   );
+}
+function saveAs(uri, filename) {
+  const link = document.createElement("a");
+
+  if (typeof link.download === "string") {
+    link.href = uri;
+    link.download = filename;
+
+    //Firefox requires the link to be in the body
+    document.body.appendChild(link);
+
+    //simulate click
+    link.click();
+
+    //remove the link when done
+    document.body.removeChild(link);
+  } else {
+    window.open(uri);
+  }
 }


### PR DESCRIPTION
Warningcards can now be downloaded as png instead of pdf (which is easier to manage on mobilephones) the downloaded image is also generated flexibly from the responsive card-element which makes the download the right size for each users individual phone instead of having a preset size.
In Progress: The code in main.js will be spread over separate files later to make the code shorter and more tidy
